### PR TITLE
Add missing fs packages to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708
 LABEL maintainers="Gorka Eguileor <geguileo@redhat.com>"
 LABEL description="Cinderlib CSI Plugin"
 
-RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-release https://repos.fedorapeople.org/repos/openstack/openstack-pike/rdo-release-pike-1.noarch.rpm && yum -y install python2-pip centos-release-openstack-pike && yum -y install openstack-cinder python-rbd ceph-common && yum clean all && rm -rf /var/cache/yum && pip install --no-cache-dir --process-dependency-links cinderlib-csi 'krest>=1.3.0'
+RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-release https://repos.fedorapeople.org/repos/openstack/openstack-pike/rdo-release-pike-1.noarch.rpm && yum -y install python2-pip centos-release-openstack-pike && yum -y install openstack-cinder python-rbd ceph-common xfsprogs e2fsprogs btrfs-progs && yum clean all && rm -rf /var/cache/yum && pip install --no-cache-dir --process-dependency-links cinderlib-csi 'krest>=1.3.0'
 
 # This is the default port, but if we change it via CSI_ENDPOINT then this will
 # no longer be relevant.

--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -3,7 +3,7 @@ FROM centos:7.4.1708
 LABEL maintainers="Gorka Eguileor <geguileo@redhat.com>"
 LABEL description="Cinderlib CSI Plugin"
 
-RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-release https://repos.fedorapeople.org/repos/openstack/openstack-pike/rdo-release-pike-1.noarch.rpm && yum -y install python2-pip centos-release-openstack-pike && yum -y install openstack-cinder python-rbd ceph-common && yum clean all && rm -rf /var/cache/yum && pip install --no-cache-dir 'cinderlib>=0.2.1' 'krest>=1.3.0' 'grpcio==1.12.0rc1' 'protobuf>=3.5.0.post1' && mkdir /csi
+RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-release https://repos.fedorapeople.org/repos/openstack/openstack-pike/rdo-release-pike-1.noarch.rpm && yum -y install python2-pip centos-release-openstack-pike && yum -y install openstack-cinder python-rbd ceph-common xfsprogs e2fsprogs btrfs-progs && yum clean all && rm -rf /var/cache/yum && pip install --no-cache-dir 'cinderlib>=0.2.1' 'krest>=1.3.0' 'grpcio==1.12.0rc1' 'protobuf>=3.5.0.post1' && mkdir /csi
 
 
 # Copy cinderlib-csi from directory directory


### PR DESCRIPTION
The base centos containers does not contain xfs, ext4, btfs
userspace tools to manage these filesystem. This change adds
the necessary those packages.