### PR TITLE
Update setup.py README file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import setuptools
 
-with open('README.rst') as readme_file:
+with open('README.md') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:


### PR DESCRIPTION
Switch from rst to md was missed in the setup.py file.  This just
updates the setup.py file so that `pip install -e .` will work
again.